### PR TITLE
Add .gitignore to ignore common OS generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+Desktop.ini


### PR DESCRIPTION
This pull request adds a .gitignore file to the repository to ignore common operating system-generated files that are unnecessary for version control.